### PR TITLE
Version printing

### DIFF
--- a/scripts/pita
+++ b/scripts/pita
@@ -10,9 +10,11 @@ import argparse
 import multiprocessing as mp
 from functools import partial
 import signal
+from pkg_resources import require
 
 DEFAULT_CONFIG = "pita.yaml"
 DEFAULT_THREADS = 4
+VERSION = require("pita")[0].version
 
 p = argparse.ArgumentParser()
 p.add_argument("-c",
@@ -46,10 +48,19 @@ p.add_argument("-r",
                 default = False,
                 action = "store_true",
                 help="reannotate using existing database"
-                )
+              )
+p.add_argument("-v",
+                dest="version",
+                action="store_true",
+                help="Print the program version and exit"
+              )
 
 
 args = p.parse_args()
+if args.version:
+    print("Version: "+VERSION)
+    sys.exit()
+
 configfile = args.configfile
 
 if not os.path.exists(configfile):

--- a/scripts/pita_utr
+++ b/scripts/pita_utr
@@ -3,6 +3,10 @@ import sys
 import os
 import argparse
 from pita.utr import *
+from pkg_resources import require
+
+version = require("pita")[0].version
+print(version)
 
 p = argparse.ArgumentParser()
 p.add_argument("-i",

--- a/scripts/pita_utr
+++ b/scripts/pita_utr
@@ -4,21 +4,29 @@ import os
 import argparse
 from pita.utr import *
 from pkg_resources import require
-
 version = require("pita")[0].version
-print(version)
 
 p = argparse.ArgumentParser()
 p.add_argument("-i",
-               dest= "bedfile",
-               help="genes in BED12 format",
+                dest= "bedfile",
+                help="genes in BED12 format",
               )
 p.add_argument("-b",
-               dest= "bamfiles",
-               help="list of RNA-seq BAM files (seperated by space)",
-               nargs="+"
+                dest= "bamfiles",
+                help="list of RNA-seq BAM files (seperated by space)",
+                nargs="+"
+              )
+p.add_argument("-v",
+                action='store_true',
+                dest="version",
+                help="Print the program version and exit",
+                required=False
               )
 args = p.parse_args()
+
+if args.version:
+    print("Version: "+version)
+    sys.exit()
 
 if not args.bedfile or not args.bamfiles:
     p.print_help()


### PR DESCRIPTION
Allows pita to print the version using the following syntax.
`$ pita -v`

Making it easier to distinguish what versions are installed